### PR TITLE
Dockerfile: dependencies for building BPI-M3-bsp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN	apt-get update && apt-get install -y \
 	pkg-config \
 	libusb-1.0-0-dev \
 	python-software-properties \
-	software-properties-common
+	software-properties-common \
+	libncurses5-dev \
+	busybox
 
 ADD	dtc /usr/bin/dtc
 


### PR DESCRIPTION
Add dependencies for building [BPI-M3-bsp](https://github.com/BPI-SINOVOIP/BPI-M3-bsp):
- **ncurses-dev**: 'make menuconfig' requires the ncurses libraries.
- **busybox**: "./[pack](https://github.com/BPI-SINOVOIP/BPI-M3-bsp/blob/7e8d63cbad330a61414b1f2e4b99bbdb81823b2f/sunxi-pack/pack#L340-L341): line 340: busybox: command not found"
